### PR TITLE
some optimization for the main.cc code

### DIFF
--- a/06_MemoryBasics/src/main.cu
+++ b/06_MemoryBasics/src/main.cu
@@ -3,7 +3,7 @@
 
 
 // Declaration of a device variable in constant memory
-__device__ __constant__ int cFoo;
+__constant__ int cFoo;
 
 __global__ void ReadConstantMemory()
 {

--- a/06_MemoryBasics/src/main.cu
+++ b/06_MemoryBasics/src/main.cu
@@ -3,7 +3,7 @@
 
 
 // Declaration of a device variable in constant memory
-__constant__ int cFoo;
+__device__ __constant__ int cFoo;
 
 __global__ void ReadConstantMemory()
 {
@@ -23,14 +23,14 @@ __global__ void WriteGlobalMemory(int* __restrict dOutPtr)
     *dOutPtr = dFoo * dFoo;
 }
 
-__device__ void WriteAndPrintSharedMemory(int* sFoo)
+__device__ void WriteAndPrintSharedMemory(int* __restrict sFoo)
 {
     // Write a computed result to shared memory for other threads to see
     sFoo[threadIdx.x] = 42 * (threadIdx.x + 1);
     // We make sure that no thread prints while the other still writes (parallelism!)
     __syncwarp();
     // Print own computed result and result by neighbor
-    printf("ThreadID: %d, sFoo[0]: %d, sFoo[1]: %d\n", threadIdx.x, sFoo[0], sFoo[1]);
+    printf("ThreadID: %d, sFoo[%d]: %d \n", threadIdx.x, threadIdx.x, sFoo[threadIdx.x]);
 }
 
 __global__ void WriteAndPrintSharedMemoryFixed()
@@ -73,7 +73,7 @@ int main()
      GPU memory. Can be updated with cudaMemcpyToSymbol.
      This syntax is unusual, but this is how it should be
     */
-    cudaMemcpyToSymbol(cFoo, &bar, sizeof(int));
+    cudaMemcpyToSymbol(&cFoo, &bar, sizeof(int));
     ReadConstantMemory<<<1, 1>>>();
     cudaDeviceSynchronize();
 

--- a/08_Reductions/src/main.cu
+++ b/08_Reductions/src/main.cu
@@ -201,8 +201,8 @@ __global__ void reduceFinal(const float* __restrict input, int N)
 
     __shared__ float data[BLOCK_SIZE];
     // Already combine two values upon load from global memory.
-    data[threadIdx.x] = id < N / 2 ? input[id] : 0;
-    data[threadIdx.x] += id + N/2 < N ? input[id + N / 2] : 0;
+    data[threadIdx.x] = id < N ? input[id] : 0;
+    data[threadIdx.x] += (id + N < 2*N) ? input[id + N] : 0;
 
     for (int s = blockDim.x / 2; s > 16; s /= 2)
     {


### PR DESCRIPTION
some optimization for the main.cc code.
1. add __device__ and __restrict__ decoration for style uniform and performance.
2. an error in function call, in line: cudaMemcpyToSymbol(&cFoo, &bar, sizeof(int)); the first parameter should be pointer type.
thanks.